### PR TITLE
Workaround for immutable(?) stack configuration.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,8 @@
 #Would be nice if some of these were added by cdk init
 cdk.out
 node_modules
+cdk.context.json
 
 #WebStorm
 .idea
-
 

--- a/bin/cdk-exports-issue.ts
+++ b/bin/cdk-exports-issue.ts
@@ -6,7 +6,8 @@ import { FargateStack } from "../lib/FargateStack";
 
 const app = new cdk.App();
 const iamUsersStack = new IamUsersStack(app, 'temp-cdkexportissue-users-stack', {
-  description: 'Temporary stack to demonstrate CDK 2 cross stack exports not working issue.'
+  description: 'Temporary stack to demonstrate CDK 2 cross stack exports not working issue.',
+  env: { account: process.env.CDK_DEFAULT_ACCOUNT, region: process.env.CDK_DEFAULT_REGION },
 })
 new FargateStack(app, 'temp-cdkexportissue-stack', {
   description: 'Temporary stack to demonstrate CDK 2 cross stack exports not working issue.',

--- a/lib/FargateStack.ts
+++ b/lib/FargateStack.ts
@@ -7,17 +7,21 @@ export interface IFargateStackProps extends IFargateStackBaseProps {
 }
 
 export class FargateStack extends FargateStackBase<IFargateStackProps> {
+
   constructor(scope: Construct, id: string, private fargateStackProps: IFargateStackProps) {
     super(scope, id, fargateStackProps);
-    this._setSignerEnvironmentVariables();
   }
 
-  private _setSignerEnvironmentVariables(): void {
-    this.fargateStackProps.environment[
+  protected _augmentStackProps(props: IFargateStackProps) {
+    super._augmentStackProps(props);
+    const environment = props.environment;
+    environment[
       "DeliveriesBucketConfiguration__SignerAccessKey"
-      ] = this.fargateStackProps.signerAccessKey.ref;
-    this.fargateStackProps.environment[
+      ] = props.signerAccessKey.ref;
+    environment[
       "DeliveriesBucketConfiguration__SignerSecretAccessKey"
-      ] = this.fargateStackProps.signerAccessKey.attrSecretAccessKey;
+      ] = props.signerAccessKey.attrSecretAccessKey;
+    return props;
   }
+
 }

--- a/lib/FargateStackBase.ts
+++ b/lib/FargateStackBase.ts
@@ -4,7 +4,7 @@ import { Cluster, ContainerImage, ScalableTaskCount } from "aws-cdk-lib/aws-ecs"
 import { ApplicationLoadBalancedFargateService } from "aws-cdk-lib/aws-ecs-patterns";
 import { Vpc } from "aws-cdk-lib/aws-ec2";
 
-export interface IFargateStackBaseProps extends StackProps{
+export interface IFargateStackBaseProps extends StackProps {
   /**
    * The environment variable values that will be set for the service.
    */
@@ -23,9 +23,13 @@ export class FargateStackBase<T extends IFargateStackBaseProps> extends Stack {
     private _parameterStackBaseProps: T
   ) {
     super(scope, id, _parameterStackBaseProps);
+    this._augmentStackProps(_parameterStackBaseProps);
     this._createVpc();
     this._createCluster();
     this._createService();
+  }
+
+  protected _augmentStackProps(props: T): void {
   }
 
   private _createVpc() {
@@ -58,6 +62,5 @@ export class FargateStackBase<T extends IFargateStackBaseProps> extends Stack {
       minCapacity: 1,
       maxCapacity: 1,
     });
-
   }
 }


### PR DESCRIPTION
Work around for the fact that stack configuration is maybe immutable in CDK 2.

As far as I know, there is no documentation for CDK 2 that mentions that stack configurations are now immutable.

This workaround provides a base class method that enables configuration modification opportunity to subclasses, prior to base class constructs being created.

